### PR TITLE
Extends Stripe webhook to handle subscription creation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
   "cSpell.words": ["Favourites"],
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "git.enabled": true,
+  "git.autorefresh": true,
+  "git.decorations.enabled": true,
+  "scm.diffDecorations": "all",
+  "scm.diffDecorationsGutterVisibility": "always"
 }

--- a/packages/service/src/models/webhook.ts
+++ b/packages/service/src/models/webhook.ts
@@ -1,7 +1,7 @@
 export interface DataObject {
   object: {
     payment_intent: string;
-    billing_reason: 'subscription_cycle';
+    billing_reason: 'subscription_cycle' | 'subscription_create';
     customer: string;
     // it is unix timestamp
     current_period_end: number;

--- a/packages/service/src/templetes/emails/subscriptions.ts
+++ b/packages/service/src/templetes/emails/subscriptions.ts
@@ -56,7 +56,7 @@ export const account24hActivation = (lang: Language, date: string): BasicEmailTe
     default:
       return {
         subject: 'The PREMIUM account for 24 hours has been activated.',
-        text: 'Your account will be valid for 24 hours until: ${date}.',
+        text: `Your account will be valid for 24 hours until: ${date}.`,
       };
   }
 };
@@ -71,7 +71,7 @@ export const account1montActivation = (lang: Language, date: string): BasicEmail
     default:
       return {
         subject: 'The PREMIUM account for 1 month has been activated.',
-        text: 'Your account will be valid for 1 month until: ${date}.',
+        text: `Your account will be valid for 1 month until: ${date}.`,
       };
   }
 };


### PR DESCRIPTION
Modifies the Stripe webhook listener to handle the 'subscription_create' event, in addition to 'subscription_cycle'.

This ensures that when a new subscription is created, the user's account is properly activated and the admin receives a notification email.

Removes redundant customer.subscription.created event handling as the invoice.paid event now covers both subscription cycle and creation scenarios.
